### PR TITLE
Add support for stable rendition and variant id tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
   - "1.10"
   - "1.11"
+  - "1.13"
 
 before_install:
   - go get -t -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: go
 go:
-  - "1.10"
-  - "1.11"
   - "1.13"
 
 before_install:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/etherlabsio/go-m3u8
 
-go 1.12
+go 1.13
 
 require (
 	github.com/AlekSi/pointer v1.0.0

--- a/m3u8/mediaItem.go
+++ b/m3u8/mediaItem.go
@@ -7,18 +7,19 @@ import (
 
 // MediaItem represents a set of EXT-X-MEDIA attributes
 type MediaItem struct {
-	Type            string
-	GroupID         string
-	Name            string
-	Language        *string
-	AssocLanguage   *string
-	AutoSelect      *bool
-	Default         *bool
-	Forced          *bool
-	URI             *string
-	InStreamID      *string
-	Characteristics *string
-	Channels        *string
+	Type              string
+	GroupID           string
+	Name              string
+	Language          *string
+	AssocLanguage     *string
+	AutoSelect        *bool
+	Default           *bool
+	Forced            *bool
+	URI               *string
+	InStreamID        *string
+	Characteristics   *string
+	Channels          *string
+	StableRenditionId *string
 }
 
 // NewMediaItem parses a text line and returns a *MediaItem
@@ -26,18 +27,19 @@ func NewMediaItem(text string) (*MediaItem, error) {
 	attributes := ParseAttributes(text)
 
 	return &MediaItem{
-		Type:            attributes[TypeTag],
-		GroupID:         attributes[GroupIDTag],
-		Name:            attributes[NameTag],
-		Language:        pointerTo(attributes, LanguageTag),
-		AssocLanguage:   pointerTo(attributes, AssocLanguageTag),
-		AutoSelect:      parseYesNo(attributes, AutoSelectTag),
-		Default:         parseYesNo(attributes, DefaultTag),
-		Forced:          parseYesNo(attributes, ForcedTag),
-		URI:             pointerTo(attributes, URITag),
-		InStreamID:      pointerTo(attributes, InStreamIDTag),
-		Characteristics: pointerTo(attributes, CharacteristicsTag),
-		Channels:        pointerTo(attributes, ChannelsTag),
+		Type:              attributes[TypeTag],
+		GroupID:           attributes[GroupIDTag],
+		Name:              attributes[NameTag],
+		Language:          pointerTo(attributes, LanguageTag),
+		AssocLanguage:     pointerTo(attributes, AssocLanguageTag),
+		AutoSelect:        parseYesNo(attributes, AutoSelectTag),
+		Default:           parseYesNo(attributes, DefaultTag),
+		Forced:            parseYesNo(attributes, ForcedTag),
+		URI:               pointerTo(attributes, URITag),
+		InStreamID:        pointerTo(attributes, InStreamIDTag),
+		Characteristics:   pointerTo(attributes, CharacteristicsTag),
+		Channels:          pointerTo(attributes, ChannelsTag),
+		StableRenditionId: pointerTo(attributes, StableRenditionIDTag),
 	}, nil
 }
 
@@ -74,6 +76,9 @@ func (mi *MediaItem) String() string {
 	}
 	if mi.Channels != nil {
 		slice = append(slice, fmt.Sprintf(quotedFormatString, ChannelsTag, *mi.Channels))
+	}
+	if mi.StableRenditionId != nil {
+		slice = append(slice, fmt.Sprintf(quotedFormatString, StableRenditionIDTag, *mi.StableRenditionId))
 	}
 
 	return fmt.Sprintf("%s:%s", MediaItemTag, strings.Join(slice, ","))

--- a/m3u8/playlistItem.go
+++ b/m3u8/playlistItem.go
@@ -29,6 +29,7 @@ type PlaylistItem struct {
 	FrameRate        *float64
 	HDCPLevel        *string
 	Resolution       *Resolution
+	StableVariantID  *string
 }
 
 // NewPlaylistItem parses a text line and returns a *PlaylistItem
@@ -79,6 +80,7 @@ func NewPlaylistItem(text string) (*PlaylistItem, error) {
 		Name:             pointerTo(attributes, NameTag),
 		HDCPLevel:        pointerTo(attributes, HDCPLevelTag),
 		Resolution:       resolution,
+		StableVariantID:  pointerTo(attributes, StableVariantIDTag),
 	}, nil
 }
 
@@ -131,6 +133,9 @@ func (pi *PlaylistItem) String() string {
 	}
 	if pi.Name != nil {
 		slice = append(slice, fmt.Sprintf(quotedFormatString, NameTag, *pi.Name))
+	}
+	if pi.StableVariantID != nil {
+		slice = append(slice, fmt.Sprintf(quotedFormatString, StableVariantIDTag, *pi.StableVariantID))
 	}
 
 	attributesString := strings.Join(slice, ",")

--- a/m3u8/tags.go
+++ b/m3u8/tags.go
@@ -68,16 +68,17 @@ const (
 
 	// MediaItem tags
 
-	TypeTag            = "TYPE"
-	GroupIDTag         = "GROUP-ID"
-	AssocLanguageTag   = "ASSOC-LANGUAGE"
-	NameTag            = "NAME"
-	AutoSelectTag      = "AUTOSELECT"
-	DefaultTag         = "DEFAULT"
-	ForcedTag          = "FORCED"
-	InStreamIDTag      = "INSTREAM-ID"
-	CharacteristicsTag = "CHARACTERISTICS"
-	ChannelsTag        = "CHANNELS"
+	TypeTag              = "TYPE"
+	GroupIDTag           = "GROUP-ID"
+	AssocLanguageTag     = "ASSOC-LANGUAGE"
+	NameTag              = "NAME"
+	AutoSelectTag        = "AUTOSELECT"
+	DefaultTag           = "DEFAULT"
+	ForcedTag            = "FORCED"
+	InStreamIDTag        = "INSTREAM-ID"
+	CharacteristicsTag   = "CHARACTERISTICS"
+	ChannelsTag          = "CHANNELS"
+	StableRenditionIDTag = "STABLE-RENDITION-ID"
 
 	/// PlaylistItem tags
 
@@ -92,6 +93,7 @@ const (
 	SubtitlesTag        = "SUBTITLES"
 	ClosedCaptionsTag   = "CLOSED-CAPTIONS"
 	HDCPLevelTag        = "HDCP-LEVEL"
+	StableVariantIDTag  = "STABLE-VARIANT-ID"
 
 	// Values
 

--- a/test/mediaItem_test.go
+++ b/test/mediaItem_test.go
@@ -12,7 +12,7 @@ func TestMediaItem_Parse(t *testing.T) {
 ASSOC-LANGUAGE="spoken",NAME="Francais",AUTOSELECT=YES,
 INSTREAM-ID="SERVICE3",CHARACTERISTICS="public.html",
 CHANNELS="6",
-"DEFAULT=NO,URI="frelo/prog_index.m3u8",FORCED=YES
+"DEFAULT=NO,URI="frelo/prog_index.m3u8",STABLE-RENDITION-ID="1234",FORCED=YES
 "`
 
 	mi, err := m3u8.NewMediaItem(line)
@@ -21,6 +21,7 @@ CHANNELS="6",
 	assert.Equal(t, "audio-lo", mi.GroupID)
 	assert.Equal(t, "Francais", mi.Name)
 
+	assertNotNilEqual(t, "1234", mi.StableRenditionId)
 	assertNotNilEqual(t, "fre", mi.Language)
 	assertNotNilEqual(t, "spoken", mi.AssocLanguage)
 	assertNotNilEqual(t, true, mi.AutoSelect)
@@ -31,6 +32,6 @@ CHANNELS="6",
 	assertNotNilEqual(t, "public.html", mi.Characteristics)
 	assertNotNilEqual(t, "6", mi.Channels)
 
-	expected := "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio-lo\",LANGUAGE=\"fre\",ASSOC-LANGUAGE=\"spoken\",NAME=\"Francais\",AUTOSELECT=YES,DEFAULT=NO,URI=\"frelo/prog_index.m3u8\",FORCED=YES,INSTREAM-ID=\"SERVICE3\",CHARACTERISTICS=\"public.html\",CHANNELS=\"6\""
+	expected := "#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"audio-lo\",LANGUAGE=\"fre\",ASSOC-LANGUAGE=\"spoken\",NAME=\"Francais\",AUTOSELECT=YES,DEFAULT=NO,URI=\"frelo/prog_index.m3u8\",FORCED=YES,INSTREAM-ID=\"SERVICE3\",CHARACTERISTICS=\"public.html\",CHANNELS=\"6\",STABLE-RENDITION-ID=\"1234\""
 	assertToString(t, expected, mi)
 }

--- a/test/playlistItem_test.go
+++ b/test/playlistItem_test.go
@@ -11,7 +11,7 @@ import (
 func TestPlaylistItem_Parse(t *testing.T) {
 	line := `#EXT-X-STREAM-INF:CODECS="avc",BANDWIDTH=540,
 PROGRAM-ID=1,RESOLUTION=1920x1080,FRAME-RATE=23.976,
-AVERAGE-BANDWIDTH=550,AUDIO="test",VIDEO="test2",
+AVERAGE-BANDWIDTH=550,AUDIO="test",VIDEO="test2",STABLE-VARIANT-ID="1234"
 SUBTITLES="subs",CLOSED-CAPTIONS="caps",URI="test.url",
 NAME="1080p",HDCP-LEVEL=TYPE-0`
 
@@ -32,6 +32,7 @@ NAME="1080p",HDCP-LEVEL=TYPE-0`
 	assertNotNilEqual(t, "1080p", pi.Name)
 	assert.False(t, pi.IFrame)
 	assertNotNilEqual(t, "TYPE-0", pi.HDCPLevel)
+	assertNotNilEqual(t, "1234", pi.StableVariantID)
 }
 
 func TestPlaylistItem_ToString(t *testing.T) {
@@ -113,9 +114,10 @@ func TestPlaylistItem_ToString_2(t *testing.T) {
 		Name:             pointer.ToString("SD"),
 		HDCPLevel:        pointer.ToString("TYPE-0"),
 		ProgramID:        pointer.ToString("1"),
+		StableVariantID:  pointer.ToString("1234"),
 	}
 
-	expected := `#EXT-X-STREAM-INF:PROGRAM-ID=1,CODECS="avc",BANDWIDTH=540,AVERAGE-BANDWIDTH=500,FRAME-RATE=30.000,HDCP-LEVEL=TYPE-0,AUDIO="test",VIDEO="test2",SUBTITLES="subs",CLOSED-CAPTIONS="caps",NAME="SD"
+	expected := `#EXT-X-STREAM-INF:PROGRAM-ID=1,CODECS="avc",BANDWIDTH=540,AVERAGE-BANDWIDTH=500,FRAME-RATE=30.000,HDCP-LEVEL=TYPE-0,AUDIO="test",VIDEO="test2",SUBTITLES="subs",CLOSED-CAPTIONS="caps",NAME="SD",STABLE-VARIANT-ID="1234"
 test.url`
 	assert.Equal(t, expected, p.String())
 


### PR DESCRIPTION
The latest hls [pantos document](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis) adds new fields for MediaItem and PlaylistItem tag.

This PR adds the support for STABLE-RENDITION-ID and STABLE-VARIANT-ID fields in MediaItem and PlaylistItem tag respectively. 